### PR TITLE
Update and rename congo.md to rdcongo.md

### DIFF
--- a/markdown/public_contributions/rdcongo.md
+++ b/markdown/public_contributions/rdcongo.md
@@ -1,11 +1,11 @@
-# Top GitHub Users By Public Contributions in Congo [<img alt="Image of insights" src="https://github.com/gayanvoice/insights/blob/master/graph/373383893/small/week.png" height="24">](https://github.com/gayanvoice/insights/blob/master/readme/373383893/week.md)
+# Top GitHub Users By Public Contributions in RD Congo [<img alt="Image of insights" src="https://github.com/gayanvoice/insights/blob/master/graph/373383893/small/week.png" height="24">](https://github.com/gayanvoice/insights/blob/master/readme/373383893/week.md)
 [![Top GitHub Users](https://github.com/gayanvoice/top-github-users/actions/workflows/action.yml/badge.svg)](https://github.com/gayanvoice/top-github-users/actions/workflows/action.yml) [![Image of insights](https://github.com/gayanvoice/insights/blob/master/svg/373383893/badge.svg)](https://github.com/gayanvoice/insights/blob/master/readme/373383893/week.md)
 
 <a href="https://gayanvoice.github.io/top-github-users/index.html">
-	<img align="right" width="200" src="https://upload.wikimedia.org/wikipedia/commons/9/92/Flag_of_the_Republic_of_the_Congo.svg" alt="Congo">
+	<img align="right" width="200" src="https://upload.wikimedia.org/wikipedia/commons/6/6f/Flag_of_the_Democratic_Republic_of_the_Congo.svg" alt="RD Congo">
 </a>
 
-The `public contributions` by users in Congo on `2022/4/30 1:04 AM UTC`. This list contains users from `Congo` and cities `Brazzaville` `Pointe-noire`.
+The `public contributions` by users in Congo on `2022/4/30 1:04 AM UTC`. This list contains users from `RD Congo` and cities `Kinshasa` `Goma` `Lubumbashi`.
 
 There are `138 countries` and `674 cities` can be found [here](https://github.com/gayanvoice/top-github-users).
 


### PR DESCRIPTION
First of all, know that there are two Congo. Almost all of the people in this list, including myself, are from Congo Kinshasa and not from Brazzaville. This is the reason why I have just modified the information relating to the Congo in question. If possible the best way would be to separate the two Congo into two separate files.