### PR TITLE
Updated: Chittagong city new name to Chattogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Contribute to GitHub action [gayanvoice/top-github-users-action](https://github.
 			<code>Mymensingh</code> 
 			<code>Rajshahi</code> 
 			<code>Rangpur</code> 
-			<code>Chittagong</code> 
+			<code>Chattogram</code> 
 			<code>Khulna</code> 
 		</td>
 	</tr>


### PR DESCRIPTION
In April 2018, the Cabinet Division of the Bangladesh Government decided to change the city's name to Chattogram.

Source: https://scroll.in/latest/874200/chittagong-is-now-chattogram-as-bangladesh-revises-english-spellings-of-five-districts