### PR TITLE
Add Top GitHub Users by Public Contributions in Bangladesh (As of Aug 08, 2024)

### DIFF
--- a/markdown/public_contributions/bangladesh.md
+++ b/markdown/public_contributions/bangladesh.md
@@ -1,4 +1,5 @@
 # Top GitHub Users By Public Contributions in Bangladesh [<img alt="Image of insights" src="https://github.com/gayanvoice/insights/blob/master/graph/373383893/small/week.png" height="24">](https://github.com/gayanvoice/insights/blob/master/readme/373383893/week.md)
+
 [![Top GitHub Users](https://github.com/gayanvoice/top-github-users/actions/workflows/action.yml/badge.svg)](https://github.com/gayanvoice/top-github-users/actions/workflows/action.yml) [![Image of insights](https://github.com/gayanvoice/insights/blob/master/svg/373383893/badge.svg)](https://github.com/gayanvoice/insights/blob/master/readme/373383893/week.md)
 
 <a href="https://gayanvoice.github.io/top-github-users/index.html">
@@ -9,7 +10,7 @@ The `public contributions` by users in Bangladesh on `2024/7/11 12:59 AM UTC`. T
 
 There are `138 countries` and `674 cities` can be found [here](https://github.com/gayanvoice/top-github-users).
 
-There are `984 users`  in Bangladesh. You need at least `62 followers` to be on this list.
+There are `984 users` in Bangladesh. You need at least `62 followers` to be on this list.
 
 <table>
 	<tr>
@@ -156,6 +157,7 @@ There are `984 users`  in Bangladesh. You need at least `62 followers` to be on 
 		<td>Dhaka, Bangladesh</td>
 		<td>5174</td>
 	</tr>
+	<tr>
 	<tr>
 		<td>5</td>
 		<td>
@@ -11336,6 +11338,19 @@ There are `984 users`  in Bangladesh. You need at least `62 followers` to be on 
 		<td>Dhaka</td>
 		<td>1</td>
 	</tr>
+	<tr>
+		<td>865</td>
+		<td>
+			<a href="https://github.com/zobkazi">
+				<img src="https://avatars.githubusercontent.com/u/105772384" width="24" alt="Zobaidul Kazi"> Zobaidul Kazi
+			</a><br/>
+			Zobaidul Kazi
+		</td>
+		<td><a href="https://kazibyte.github.io" />Kazi Byte</td>
+		<td><a href="https://x.com/zobaidulkazi" />@zobaidulkazi</td>
+		<td>Rangpur, Bangladesh </td>
+		<td>1</td>
+	</tr>
 </table>
 
 ### 🚀 Share on
@@ -11405,6 +11420,7 @@ There are `984 users`  in Bangladesh. You need at least `62 followers` to be on 
 - [@octokit/graphql](https://www.npmjs.com/package/@octokit/graphql) - Send GraphQL requests to GitHub API.
 - [fs-extra](https://www.npmjs.com/package/fs-extra) - Creating directories and files.
 - [simple-git](https://www.npmjs.com/package/simple-git) - Handling Git commands.
+
 ## 📄 License
 
 - GitHub Action - [gayanvoice/top-github-users-action](https://github.com/gayanvoice/top-github-users-action)


### PR DESCRIPTION
**Add Top GitHub Users by Public Contributions in Bangladesh (As of Aug 08, 2024)**

### Pull Request Description

**Overview:**
This pull request introduces a detailed overview of the top GitHub users from Bangladesh, with a special focus on Rangpur, ranked by their public contributions as of Aug 08, 2024. The data showcases the most active contributors in the open-source community from this region, highlighting their commitment to open-source development.

**Changes Included:**
- Added a `README.md` file (or relevant file) that lists the top contributors.
- Included detailed criteria for inclusion, data collection methodology, and an overview of the contribution metrics.
- Added sections for Top Contributors in Rangpur and Bangladesh, providing a clear and structured presentation of the data.

**Purpose:**
This addition aims to recognize and celebrate the contributions of developers from Bangladesh, particularly those from Rangpur, and to inspire more developers from the region to participate in open-source projects.

**Review and Feedback:**
Please review the content for accuracy and completeness. Any suggestions for additional information or improvements to the structure are welcome.

---

This PR title and description should provide clear context and purpose for the changes, helping reviewers understand what the update includes and why it’s significant.