### PR TITLE
Add Cluj-Napoca as city for Romania

### DIFF
--- a/config.json
+++ b/config.json
@@ -104,7 +104,7 @@
     { "country":  "poland", "geoName": "Poland", "cities": ["warsaw", "kraków", "wrocław", "gdańsk", "poznań"], "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/12/Flag_of_Poland.svg" },
     { "country":  "portugal", "geoName": "Portugal", "cities": ["lisbon", "porto", "braga", "coimbra"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/5c/Flag_of_Portugal.svg" },
     { "country":  "qatar", "geoName": "Qatar", "cities": ["doha"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/65/Flag_of_Qatar.svg" },
-    { "country":  "romania", "geoName": "Romania", "cities": ["bucharest", "constanța"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/73/Flag_of_Romania.svg" },
+    { "country":  "romania", "geoName": "Romania", "cities": ["bucharest", "constanța", "cluj-napoca"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/73/Flag_of_Romania.svg" },
     { "country":  "russia", "geoName": "Russia", "cities": ["moscow", "saint-petersburg", "yekaterinburg", "novosibirsk", "kazan", "omsk", "volgograd", "chelyabinsk", "krasnoyarsk"], "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f3/Flag_of_Russia.svg" },
     { "country":  "rwanda", "geoName": "Rwanda", "cities": ["kigali"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/17/Flag_of_Rwanda.svg" },
     { "country":  "san marino", "geoName": "San Marino", "cities": ["marino"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b1/Flag_of_San_Marino.svg" },


### PR DESCRIPTION
## Add Cluj-Napoca as city for Romania

This PR adds Cluj-Napoca to the list of cities for Romania in the configuration.

### Why Cluj-Napoca?

Cluj-Napoca is Romania's second-largest tech hub with approximately 26,000 IT professionals (12% of the country's total) and over 1,300 software companies. The city has built a reputation as a concentrated innovation center with strong universities, a thriving startup scene, and a globally-minded developer community that punches well above its weight compared to the capital.

### Changes

- Added `cluj-napoca` to the cities array for Romania in `config.json`

This will enable tracking and ranking of GitHub users from Cluj-Napoca alongside Bucharest and Constanța.