### PR TITLE
Fix Georgia country/state ambiguity using Sakartvelo

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,7 +47,7 @@
     { "country":  "ethiopia", "geoName": "Ethiopia", "cities": ["addis-ababa", "dire-dawa", "dire-dawa", "hawassa", "dessie"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/71/Flag_of_Ethiopia.svg" },
     { "country":  "finland", "geoName": "Finland", "cities": ["helsinki", "tampere", "oulu", "espoo", "vantaa"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/bc/Flag_of_Finland.svg" },
     { "country":  "france", "geoName": "France", "cities": ["paris", "marseille", "lyon", "bordeaux", "toulouse", "strasbourg", "nice", "nantes", "montpellier", "lille"], "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c3/Flag_of_France.svg" },
-    { "country":  "georgia", "geoName": "Georgia", "cities": ["tbilisi", "batumi", "kutaisi", "rustavi"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0f/Flag_of_Georgia.svg" },
+    { "country":  "sakartvelo", "geoName": "Georgia", "cities": ["tbilisi", "batumi", "kutaisi", "rustavi"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0f/Flag_of_Georgia.svg" },
     { "country":  "germany", "geoName": "Germany", "cities": ["berlin", "munich", "hamburg", "cologne", "hamburg", "düsseldorf", "stuttgart", "dresden"], "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/ba/Flag_of_Germany.svg" },
     { "country":  "ghana", "geoName": "Ghana", "cities": ["accra", "kumasi", "sekondi-takoradi", "sunyani", "tamale", "obuasi"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/11/Ghana_Flag.svg" },
     { "country":  "greece", "geoName": "Greece", "cities": ["athens", "thessaloniki", "patras", "heraklion", "ioannina", "pireas", "volos", "agrinio"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/5c/Flag_of_Greece.svg" },


### PR DESCRIPTION
Fixes #291

This updates Georgia country matching to use "Sakartvelo" in `config.json:50`, avoiding ambiguity with Georgia (USA).