### PR TITLE
Add The Gambia to country configuration for GitHub user tracking

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,6 +47,7 @@
     { "country":  "ethiopia", "geoName": "Ethiopia", "cities": ["addis-ababa", "dire-dawa", "dire-dawa", "hawassa", "dessie"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/71/Flag_of_Ethiopia.svg" },
     { "country":  "finland", "geoName": "Finland", "cities": ["helsinki", "tampere", "oulu", "espoo", "vantaa"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/bc/Flag_of_Finland.svg" },
     { "country":  "france", "geoName": "France", "cities": ["paris", "marseille", "lyon", "bordeaux", "toulouse", "strasbourg", "nice", "nantes", "montpellier", "lille"], "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c3/Flag_of_France.svg" },
+    { "country":  "gambia", "geoName": "The Gambia", "cities": ["banjul", "serekunda", "serrekunda", "brikama", "bakau", "fajara", "sukuta"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/77/Flag_of_The_Gambia.svg" },
     { "country":  "georgia", "geoName": "Georgia", "cities": ["tbilisi", "batumi", "kutaisi", "rustavi"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0f/Flag_of_Georgia.svg" },
     { "country":  "germany", "geoName": "Germany", "cities": ["berlin", "munich", "hamburg", "cologne", "hamburg", "düsseldorf", "stuttgart", "dresden"], "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/ba/Flag_of_Germany.svg" },
     { "country":  "ghana", "geoName": "Ghana", "cities": ["accra", "kumasi", "sekondi-takoradi", "sunyani", "tamale", "obuasi"], "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/11/Ghana_Flag.svg" },


### PR DESCRIPTION
This PR adds **The Gambia** to the country configuration so that developers from the region can now be properly included in the ranking and tracking system.

We introduced a new country entry following the existing format used across the project.

---
📌 Why this matters

This update improves geographic coverage by adding The Gambia, ensuring developers from major Gambian tech hubs are now recognized in the dataset.

It also helps improve fairness and accuracy in regional GitHub user rankings by including an underrepresented but growing developer community.

✅ Summary
- Added new country entry: The Gambia
- Included major cities and tech hubs
- Added official flag image reference
- Fully compatible with existing configuration structure
- No breaking changes introduced

---

## 🇬🇲 What was added

```{
  "country": "gambia",
  "geoName": "The Gambia",
  "cities": [
    "banjul",
    "serekunda",
    "serrekunda",
    "brikama",
    "bakau",
    "fajara",
    "sukuta"
  ],
  "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/77/Flag_of_The_Gambia.svg"
}

